### PR TITLE
1.3.1

### DIFF
--- a/Checklist/Checklist.CheckJawTracking.cs
+++ b/Checklist/Checklist.CheckJawTracking.cs
@@ -1,0 +1,60 @@
+﻿//Added by JSR, 2018-01-09
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Text;
+using System.Windows;
+using VMS.TPS.Common.Model.API;
+using VMS.TPS.Common.Model.Types;
+using System.Windows.Forms;
+using System.IO;
+
+namespace Checklist
+{
+    public partial class Checklist
+    {
+        private Tuple<string,AutoCheckStatus> CheckJawTracking(PlanSetup planSetup)
+        {
+            string stringOut = string.Empty;
+            string beamWithJTText = string.Empty;
+            bool isTB = false;
+            foreach (Beam beam in planSetup.Beams)
+            {
+                List<double> delta_x1 = new List<double>();
+                List<double> delta_x2 = new List<double>();
+                List<double> delta_y1 = new List<double>();
+                List<double> delta_y2 = new List<double>();
+                
+                double jaw_x1_0 = beam.ControlPoints[0].JawPositions.X1;
+                double jaw_x2_0 = beam.ControlPoints[0].JawPositions.X2;
+                double jaw_y1_0 = beam.ControlPoints[0].JawPositions.Y1;
+                double jaw_y2_0 = beam.ControlPoints[0].JawPositions.Y2;
+                if (!beam.IsSetupField)
+                {
+
+                    if (beam.TreatmentUnit.Id.IndexOf("TB") == 0)
+                        isTB = true; 
+                    for (int i = 1; i < beam.ControlPoints.Count; i++)
+                    {
+
+                        delta_x1.Add(jaw_x1_0 - beam.ControlPoints[i].JawPositions.X1);
+                        delta_x2.Add(jaw_x2_0 - beam.ControlPoints[i].JawPositions.X2);
+                        delta_y1.Add(jaw_y1_0 - beam.ControlPoints[i].JawPositions.Y1);
+                        delta_x2.Add(jaw_y2_0 - beam.ControlPoints[i].JawPositions.Y2);
+
+                    }
+                    if (delta_x1.Sum() != 0 || delta_x2.Sum() != 0 || delta_y1.Sum() != 0 || delta_y2.Sum() != 0)
+                        beamWithJTText += (String.IsNullOrEmpty(beamWithJTText) ? "" : ", ") + beam.Id;
+                }
+            }
+
+            if (String.IsNullOrEmpty(beamWithJTText))
+            { 
+                return new Tuple<string,AutoCheckStatus>("Jawtracking är ej aktivt, verifiera",(isTB ? AutoCheckStatus.WARNING : AutoCheckStatus.MANUAL ));
+            }
+            else
+                return new Tuple<string, AutoCheckStatus>("Jawtracking är aktivt för fält: " + beamWithJTText,AutoCheckStatus.MANUAL); 
+        }
+        
+    }
+}

--- a/Checklist/Checklist.GetOptimizationInfo.cs
+++ b/Checklist/Checklist.GetOptimizationInfo.cs
@@ -1,0 +1,74 @@
+﻿//Added by JSR, 2018-01-09
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Text;
+using System.Windows;
+using VMS.TPS.Common.Model.API;
+using VMS.TPS.Common.Model.Types;
+using System.Windows.Forms;
+using System.IO;
+
+namespace Checklist
+{
+    public partial class Checklist
+    {
+        private Tuple<string, string, AutoCheckStatus> GetOptimizationInfo(StructureSet structureSet, PlanSetup planSetup)
+        {
+            string value = string.Empty;
+            string details = string.Empty;
+            AutoCheckStatus status = AutoCheckStatus.MANUAL; 
+            List<Structure> strList = structureSet.Structures.Where(s => s.Id.ToLower().StartsWith("z_ptv")).ToList();
+
+            List<string> lowerPTVObjectiveStructures = new List<string>(); //J Add list for name of all structures that have an lower objective
+
+            foreach (OptimizationObjective optimizationObjective in planSetup.OptimizationSetup.Objectives)
+                if (optimizationObjective.GetType() == typeof(OptimizationPointObjective))
+                {
+                    OptimizationPointObjective optimizationPointObjective = (OptimizationPointObjective)optimizationObjective;
+                    if (((optimizationPointObjective.Operator.ToString().ToLower() == "lower") || (optimizationPointObjective.Operator.ToString().ToLower() == "upper")) && optimizationPointObjective.StructureId.StartsWith("Z_PTV"))
+                    {
+                        // Generates a list for with name of all structures that have a lower objective (ie finds the PTVs). 
+                        lowerPTVObjectiveStructures.Add(optimizationPointObjective.StructureId);
+                    }
+                    details += (details.Length == 0 ? "Optimization objectives:\r\n  " : "\r\n  ") + optimizationPointObjective.StructureId + ": " + optimizationPointObjective.Operator.ToString() + ", dose: " + optimizationPointObjective.Dose.Dose.ToString("0.000") + ", volume: " + optimizationPointObjective.Volume.ToString("0.0") + ", priority: " + optimizationPointObjective.Priority.ToString();
+                }
+            if (!strList.Any() && !lowerPTVObjectiveStructures.Any())
+            {
+                value += "Inget optimeringsPTV hittat, verifera";
+                status = AutoCheckStatus.MANUAL;
+            }
+            else if (strList.Any() && !lowerPTVObjectiveStructures.Any())
+            {
+                value += "OptimeringsPTV har ritats men ej används i optimering, vänligen verifera";
+                status = AutoCheckStatus.WARNING;
+            }
+            else if (strList.Any() && lowerPTVObjectiveStructures.Any())
+            {
+                value += "OptimeringsPTV har ritats och använts optimering, vänligen verifiera";
+                status = AutoCheckStatus.MANUAL;
+            }
+
+            // JSR 
+            foreach (OptimizationParameter optimizationParameter in planSetup.OptimizationSetup.Parameters)
+            {
+                if (optimizationParameter.GetType() == typeof(OptimizationPointCloudParameter))
+                {
+                    OptimizationPointCloudParameter optimizationPointCloudParameter = (OptimizationPointCloudParameter)optimizationParameter;
+                    details += (details.Length == 0 ? string.Empty : "\r\n") + "Point cloud parameter: " + optimizationPointCloudParameter.Structure.Id + "=" + optimizationPointCloudParameter.Structure.DicomType.ToString();
+                }
+                else if (optimizationParameter.GetType() == typeof(OptimizationNormalTissueParameter))
+                {
+                    OptimizationNormalTissueParameter optimizationNormalTissueParameter = (OptimizationNormalTissueParameter)optimizationParameter;
+                    details += (details.Length == 0 ? string.Empty : "\r\n") + "Normal tissue parameter: priority=" + optimizationNormalTissueParameter.Priority.ToString();
+                }
+                else if (optimizationParameter.GetType() == typeof(OptimizationExcludeStructureParameter))
+                {
+                    OptimizationExcludeStructureParameter optimizationExcludeStructureParameter = (OptimizationExcludeStructureParameter)optimizationParameter;
+                    details += (details.Length == 0 ? string.Empty : "\r\n") + "Exclude structure parameter: " + optimizationExcludeStructureParameter.Structure.Id;
+                }
+            }
+            return new Tuple<string, string, AutoCheckStatus>(value, details, status); 
+        }
+    }
+}

--- a/Checklist/Tests/Checklist.B.cs
+++ b/Checklist/Tests/Checklist.B.cs
@@ -18,18 +18,33 @@ namespace Checklist
             if (planSetup.StructureSet != null)
             {
                 bool tpsBolusExist = false;
+                bool tpsBolusLinkedToField = false; 
                 foreach (Structure structure in planSetup.StructureSet.Structures)
                 {
                     if (string.Compare(structure.DicomType, "BOLUS") == 0)
+                    {
                         tpsBolusExist = true;
+                        
+                    }
+                }
+                foreach (Beam b in planSetup.Beams)
+                {
+                    if (b.Boluses.Count() > 0)
+                        tpsBolusLinkedToField = true;
+
                 }
                 if (!tpsBolusExist)
                 {
                     b1_value = "Ej ansatt";
                     b1_status = AutoCheckStatus.PASS;
                 }
-                else
-                    b1_value = "Bolus har ansatts i TPS";
+                else if (tpsBolusExist && !tpsBolusLinkedToField)
+                {
+                    b1_value = "Bolus har ansatts i TPS, men ej kopplats till minst ett fält. Verifera.";
+                    b1_status = AutoCheckStatus.WARNING;
+                }
+                else if (tpsBolusExist && tpsBolusLinkedToField)
+                    b1_value = "Bolus har ansatts i TPS, och kopplats till minst ett fält. Verifiera.";
             }
             else
                 b1_value = "StructureSet saknas";

--- a/Checklist/Tests/Checklist.P.cs
+++ b/Checklist/Tests/Checklist.P.cs
@@ -433,7 +433,7 @@ namespace Checklist
             {
                 p11_status = AutoCheckStatus.FAIL;
             }
-            checklistItems.Add(new ChecklistItem("P11. Normering är korrekt", "Kontrollera att planen är normerad på korrekt vis \r\n  • Icke-normerade planer accepteras ej. \r\n  • Normalt till targetvolymens medeldos (om särskilt skäl föreligger kan en punktnormering användas). \r\n  • För stereotaktiska lungor i Eclipse normeras dosen till isocenter och ordineras till 75%-isodosen.\r\n  • För VMAT ska Plan Normalization Value skall normeringsvärdet vara i intervallet [0.970, 1.030].", p11_value, p11_status));
+            checklistItems.Add(new ChecklistItem("P11. Normering är korrekt", "Kontrollera att planen är normerad på korrekt vis \r\n  • Icke-normerade planer accepteras ej. \r\n  • Normalt till targetvolymens mediandos (om särskilt skäl föreligger kan en punktnormering användas). \r\n  • För stereotaktiska lungor i Eclipse normeras dosen till isocenter och ordineras till 75%-isodosen.\r\n  • För VMAT ska Plan Normalization Value skall normeringsvärdet vara i intervallet [0.970, 1.030].", p11_value, p11_status));
 
             string p12_value = string.Empty;            
             string p13_value = string.Empty;

--- a/Checklist/Tests/Checklist.U.cs
+++ b/Checklist/Tests/Checklist.U.cs
@@ -12,7 +12,7 @@ namespace Checklist
     {
         public void U() // The name U is kept for historical reasons. Might change to R in future versions.
         {
-            checklistItems.Add(new ChecklistItem("R. Remiss/Ordination"));
+            checklistItems.Add(new ChecklistItem("R. Strålanmälan/Ordination"));
 
             string r1_imageid = string.Empty;
             if (planSetup.StructureSet != null && planSetup.StructureSet.Image != null)
@@ -28,7 +28,7 @@ namespace Checklist
                 if (count > 1)
                     MessageBox.Show(remark, "Aktuella remarks");
             }
-            checklistItems.Add(new ChecklistItem("R1. Jämför id (course, plan, CT-set, patient) mellan remiss, protokoll och Aria", "Kontrollera att \r\n  • Patientens personnummer stämmer överens mellan remiss, protokoll och Aria\r\n  • Course, plannamn och CT-set stämmer överens mellan protokoll och Aria.", r1_value, AutoCheckStatus.MANUAL));
+            checklistItems.Add(new ChecklistItem("R1. Jämför id (course, plan, CT-set, patient) mellan strålanmälan, protokoll och Aria", "Kontrollera att \r\n  • Patientens personnummer stämmer överens mellan strålanmälan, protokoll och Aria\r\n  • Course, plannamn och CT-set stämmer överens mellan protokoll och Aria.", r1_value, AutoCheckStatus.MANUAL));
 
             AutoCheckStatus r2_status = AutoCheckStatus.FAIL;
             string r2_value = string.Empty;

--- a/Checklist/Tests/Checklist.V.cs
+++ b/Checklist/Tests/Checklist.V.cs
@@ -20,7 +20,6 @@ namespace Checklist
                 int v1_numberOfWarnings = 0;
                 int v1_numberOfPass = 0;
                 List<double> collAngles = new List<double>();
-                List<string> lowerPTVObjectiveStructures = new List<string>(); //J Add list for name of all structures that have an lower objective
                 foreach (Beam beam in planSetup.Beams)
                 {
                     if (!beam.IsSetupField)
@@ -52,7 +51,7 @@ namespace Checklist
 
                 checklistItems.Add(new ChecklistItem("V1. Kollimatorvinkeln är lämplig", "Kontrollera att kollimatorvinkeln är lämplig\r\n  • Varian: vanligtvis 5° resp. 355°, men passar detta ej PTV är andra vinklar ok (dock ej vinklar mellan 355° och 5°)\r\n  • Elekta: 30° resp. 330°", v1_value, v1_status));
                                 
-                if (checklistType == ChecklistType.EclipseVMAT && treatmentUnitManufacturer == TreatmentUnitManufacturer.Varian)
+                if (checklistType == ChecklistType.EclipseVMAT)//JSR && treatmentUnitManufacturer == TreatmentUnitManufacturer.Varian)
                 {
                     string v2_value = string.Empty;
                     AutoCheckStatus v2_status = AutoCheckStatus.WARNING;
@@ -74,64 +73,29 @@ namespace Checklist
                     string v3_details = string.Empty;
                     string v3_value = string.Empty;
                     AutoCheckStatus v3_status = AutoCheckStatus.MANUAL;
+                    
+
                     if (planSetup.OptimizationSetup != null)
                     {
-                        // JSR 
-                        List<Structure> strList = structureSet.Structures.Where(s => s.Id.StartsWith("Z_PTV")).ToList(); 
+                        var v3 = GetOptimizationInfo(structureSet, planSetup);
+                        v3_value = v3.Item1;
+                        v3_details = v3.Item2;
+                        v3_status = v3.Item3; 
                         
-                        
-                            foreach (OptimizationObjective optimizationObjective in planSetup.OptimizationSetup.Objectives)
-                                if (optimizationObjective.GetType() == typeof(OptimizationPointObjective))
-                                {
-                                    OptimizationPointObjective optimizationPointObjective = (OptimizationPointObjective)optimizationObjective;
-                                    if ((optimizationPointObjective.Operator.ToString().ToLower() == "lower") && optimizationPointObjective.StructureId.StartsWith("Z_PTV"))
-                                    {
-                                        // Generates a list for with name of all structures that have a lower objective (ie finds the PTVs). 
-                                        lowerPTVObjectiveStructures.Add(optimizationPointObjective.StructureId);
-                                    }
-                                    v3_details += (v3_details.Length == 0 ? "Optimization objectives:\r\n  " : "\r\n  ") + optimizationPointObjective.StructureId + ": " + optimizationPointObjective.Operator.ToString() + ", dose: " + optimizationPointObjective.Dose.Dose.ToString("0.000") + ", volume: " + optimizationPointObjective.Volume.ToString("0.0") + ", priority: " + optimizationPointObjective.Priority.ToString();
-                                }
-                        if (!strList.Any() && !lowerPTVObjectiveStructures.Any())
-                        { 
-                                v3_value += "Inget optimeringsPTV hittat, verifera"; 
-                                v3_status = AutoCheckStatus.MANUAL;
-                        }
-                        else if (strList.Any() && !lowerPTVObjectiveStructures.Any())
-                        { 
-                                v3_value += "OptimeringsPTV har ritats men ej används i optimering, vänligen verifera";
-                                v3_status = AutoCheckStatus.WARNING;
-                        }
-                        else if (strList.Any() && lowerPTVObjectiveStructures.Any())
-                        { 
-                                v3_value += "OptimeringsPTV har ritats och använts optimering, vänligen verifiera";
-                                v3_status = AutoCheckStatus.MANUAL;
-                        }
-
-                        // JSR 
-                        foreach (OptimizationParameter optimizationParameter in planSetup.OptimizationSetup.Parameters)
-                        {
-                            if (optimizationParameter.GetType() == typeof(OptimizationPointCloudParameter))
-                            {
-                                OptimizationPointCloudParameter optimizationPointCloudParameter = (OptimizationPointCloudParameter)optimizationParameter;
-                                v3_details += (v3_details.Length == 0 ? string.Empty : "\r\n") + "Point cloud parameter: " + optimizationPointCloudParameter.Structure.Id + "=" + optimizationPointCloudParameter.Structure.DicomType.ToString();
-                            }
-                            else if (optimizationParameter.GetType() == typeof(OptimizationNormalTissueParameter))
-                            {
-                                OptimizationNormalTissueParameter optimizationNormalTissueParameter = (OptimizationNormalTissueParameter)optimizationParameter;
-                                v3_details += (v3_details.Length == 0 ? string.Empty : "\r\n") + "Normal tissue parameter: priority=" + optimizationNormalTissueParameter.Priority.ToString();
-                            }
-                            else if (optimizationParameter.GetType() == typeof(OptimizationExcludeStructureParameter))
-                            {
-                                OptimizationExcludeStructureParameter optimizationExcludeStructureParameter = (OptimizationExcludeStructureParameter)optimizationParameter;
-                                v3_details += (v3_details.Length == 0 ? string.Empty : "\r\n") + "Exclude structure parameter: " + optimizationExcludeStructureParameter.Structure.Id;
-                            }
-                        }
                     }
                     checklistItems.Add(new ChecklistItem("V3. Optimeringsbolus och optimeringsPTV är korrekt använt", "Kontrollera att optimeringsbolus har använts korrekt för ytliga target:	\r\n  Eclipse H&N (VMAT):\r\n    • Optimerings-PTV har använts vid optimeringen i de fall då PTV har beskurits med hänsyn till ytterkonturen\r\n    • HELP_BODY inkluderar både patientens ytterkontur (BODY) och optimeringsbolus\r\n  Eclipse Ani, Recti (VMAT):\r\n    • BODY ska inkludera eventuellt optimeringsbolus\r\n  Optimeringsbolus i Eclipse (VMAT):\r\n    • HU för optimeringsbolus är satt till 0 HU\r\n    • Optimeringsbolus är skapat genom 5 mm (H&N) eller 6 mm (Ani, Recti) expansion från det PTV-struktur optimeringen skett på. Boluset ska ej gå innanför patientens hudyta.", v3_value, v3_details, v3_status)); //JSR
 
                     checklistItems.Add(new ChecklistItem("V4. Robusthet", "Kontrollera planens robusthet m.a.p. ISO-center-förskjutning m.h.a. Uncertainty-planer. Planerna skapas av dosplaneraren.\r\n    • Skillnaderna i maxdos för uncertainty-planerna (±0,4 cm i x, y, resp. z) är <5% relativt originalplanen.\r\n    • CTV täckning är acceptabel.", string.Empty, AutoCheckStatus.MANUAL));
 
-                    checklistItems.Add(new ChecklistItem("V5. Leveransmönstret är rimligt", "Kontrollera att leveransmönstret är rimligt (att det inte är en stor andel extremt små öppningar och att riskorgan skärmas, samt att alla segment går på ett target)", string.Empty, AutoCheckStatus.MANUAL));
+                    // Check for jawtracking: 
+                    var v5_values = CheckJawTracking(planSetup);
+                    
+                    string v5_value = v5_values.Item1;
+                    AutoCheckStatus v5_status = v5_values.Item2; 
+                                        
+                    checklistItems.Add(new ChecklistItem("V5. Leveransmönstret är rimligt", "Kontrollera att leveransmönstret är rimligt (att det inte är en stor andel extremt små öppningar, att riskorgan skärmas, att alla segment går på ett target samt jawtracking för kollimatorerna)", v5_value, v5_status));
+
+                    
                 }
             }
         }

--- a/Checklista.csproj
+++ b/Checklista.csproj
@@ -67,10 +67,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Checklist\Checklist.CheckJawTracking.cs" />
     <None Include="Checklist\OldChecks.cs" />
     <Compile Include="Checklist\Checklist.BeamParameter.cs" />
     <Compile Include="Checklist\Checklist.GetIsSplitVMAT.cs" />
     <Compile Include="Checklist\Checklist.ElektaMLCcheck.cs" />
+    <Compile Include="Checklist\Checklist.GetOptimizationInfo.cs" />
     <Compile Include="Checklist\Checklist.GetVMATCoplanar.cs" />
     <Compile Include="Checklist\Checklist.ValidateMRparameters.cs" />
     <Compile Include="Checklist\Checklist.VarianMLCCheck.cs" />


### PR DESCRIPTION
Added: Additional check for bolus, warning will be given if a virtual bolus is not connected to treatment field.
Correct warning flag for prefered gantry and collimator angle rotation for elekta VMAT.

Moved Optimization check into a separate .cs file.

Added Check for Jawtracking.

Added Autocheck ok in cases of all beams (incl setup) have couchangle 0.